### PR TITLE
Implement EventBus

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,22 +12,19 @@ env:
 
 jobs:
   RSpec:
+    name: RSpec
     runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
-    strategy:
-      matrix:
-        ruby:
-          - $RUBY_VERSION
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby }}
+        ruby-version: ${{ env.RUBY_VERSION }}
         bundler-cache: true
+
     - name: Run the default task
-      run: bundle exec rake
+      run: bundle exec rspec
 
   Lint:
     name: Lint 🔎
@@ -35,18 +32,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: $RUBY_VERSION
-
-      - name: Install dependencies
-        run: bundle install
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
 
       - name: Run
-        run: rake standard
+        run: bundle exec rake standard
 
   TypeCheck:
     name: Type Check🩺
@@ -54,15 +49,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: $RUBY_VERSION
-
-      - name: Install dependencies
-        run: bundle install
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
 
       - name: Run
-        run: steep check --severity-level=error
+        run: bundle exec steep check --severity-level=error

--- a/lib/next/core.rb
+++ b/lib/next/core.rb
@@ -141,9 +141,8 @@ module Next
       !@actor.nil?
     end
 
-    private def actor=(value)
-      @actor = value
-    end
+    attr_writer :actor
+    private :actor=
 
     private def terminating?
       @terminating

--- a/lib/next/event_bus.rb
+++ b/lib/next/event_bus.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Next
+  # The EventBus class enables other actors to subscribe to specific events and receive
+  # notifications when these events are published to the event bus. Here is an example of
+  # how to use this functionality:
+  #
+  #   event_bus = system.actor_of(EventBus.props)
+  #   event_bus.tell EventBus::Subscribe.new(event: Numeric, subscriber: actor_ref2)
+  #   event_bus.tell EventBus::Subscribe.new(event: Float, subscriber: actor_ref2)
+  #   event_bus.tell EventBus::Publish.new(event: 42.2)
+  #
+  # In the above example, only +actor_ref2+ receives the +42.2+ message. However, if you publish +424+
+  # it will be received by both actors.
+  #
+  # @api private
+  class EventBus < Actor
+    attr_reader :subscriptions
+
+    Subscribe = Data.define(:event, :subscriber)
+    Publish = Data.define(:event)
+
+    def self.props = Next.props(self)
+
+    def initialize
+      @subscriptions = Hash.new do |subscribers, matcher|
+        subscribers[matcher] = Set.new
+      end
+    end
+
+    def receive(message)
+      case message
+      in Subscribe(event:, subscriber:)
+        create_subscription(event:, subscriber:)
+      in Publish(event:)
+        publish_event(event:)
+      end
+    end
+
+    private def create_subscription(event:, subscriber:)
+      subscriptions[event].add(subscriber)
+    end
+
+    private def publish_event(event:)
+      subscribers(event).each do |subscriber|
+        subscriber.tell(event)
+      end
+    end
+
+    private def subscribers(event)
+      subscriptions.each_with_object(Set.new) do |(matcher, subscribers), acc|
+        if matcher === event
+          acc.merge(subscribers)
+        end
+      end
+    end
+  end
+end

--- a/lib/next/serialized_execution.rb
+++ b/lib/next/serialized_execution.rb
@@ -94,7 +94,7 @@ module Next
       did_it_run = begin
         job.executor.post { work(job) }
         true
-      rescue Concurrent::RejectedExecutionError => ex
+      rescue Concurrent::RejectedExecutionError
         false
       end
 

--- a/sig/next/event_bus.rbs
+++ b/sig/next/event_bus.rbs
@@ -1,0 +1,19 @@
+module Next
+  class EventBus < Actor
+    def self.props: -> Props[EventBus]
+
+    attr_reader subscriptions: Hash[untyped, Set[Reference]]
+
+    def initialize: -> void
+
+    def receive: (untyped) -> void
+
+    private
+
+    def create_subscription: (event: untyped, subscriber: Reference) -> void
+
+    def publish_event: (event: untyped) -> void
+
+    def subscribers: (untyped) -> Set[Reference]
+  end
+end

--- a/sig/next/event_bus/publish.rbs
+++ b/sig/next/event_bus/publish.rbs
@@ -1,0 +1,10 @@
+module Next
+  class EventBus < Actor
+    class Publish < Data
+      attr_reader event: untyped
+
+      def self.new: (event: untyped) -> instance
+                  | (untyped) -> instance
+    end
+  end
+end

--- a/sig/next/event_bus/subscribe.rbs
+++ b/sig/next/event_bus/subscribe.rbs
@@ -1,0 +1,11 @@
+module Next
+  class EventBus < Actor
+    class Subscribe < Data
+      attr_reader event: untyped
+      attr_reader subscriber: Reference
+
+      def self.new: (event: untyped, subscriber: Reference) -> instance
+                  | (untyped, Reference) -> instance
+    end
+  end
+end

--- a/spec/next/actor_lifecycle_spec.rb
+++ b/spec/next/actor_lifecycle_spec.rb
@@ -143,16 +143,16 @@ RSpec.describe Next::Actor, :actor_system do
         end
       end
 
-      def object_id
+      def object_identifier
         expect_message { |message| /Hello from #pre_start/.match?(message) }.split("object_id=").last
       end
 
       it "executes #pre_start hook" do
-        object_id_before_recreate = object_id
+        object_id_before_recreate = object_identifier
 
         actor << Next::SystemMessages::Recreate.new(StandardError.new)
 
-        expect(object_id).not_to eq(object_id_before_recreate), "should instantiate a new actor"
+        expect(object_identifier).not_to eq(object_id_before_recreate), "should instantiate a new actor"
 
         expect_no_message(timeout: 0.5)
       end

--- a/spec/next/event_bus_spec.rb
+++ b/spec/next/event_bus_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+RSpec.describe Next::EventBus, :actor_system do
+  let(:event_bus) { system.actor_of(described_class.props) }
+
+  def subscribe(...) = Next::EventBus::Subscribe.new(...)
+
+  def publish(...) = Next::EventBus::Publish.new(...)
+
+  context "when subscribed to the same event twice" do
+    before do
+      event_bus.tell subscribe(event: Numeric, subscriber: test_actor)
+      event_bus.tell subscribe(event: Numeric, subscriber: test_actor)
+    end
+
+    it "does not receive the same event twice" do
+      event_bus.tell publish(event: 42)
+
+      expect_message(42)
+      expect_no_message(timeout: 0.1)
+    end
+  end
+
+  context "when subscribed a superclass of an event" do
+    before do
+      event_bus.tell subscribe(event: Numeric, subscriber: test_actor)
+    end
+
+    it "receives matching event" do
+      event_bus.tell publish(event: 42.0)
+
+      expect_message(42.0)
+    end
+  end
+
+  context "when subscribed a superclass of an event and to event itself" do
+    before do
+      event_bus.tell subscribe(event: Numeric, subscriber: test_actor)
+      event_bus.tell subscribe(event: Float, subscriber: test_actor)
+    end
+
+    it "does not receive the same event twice" do
+      event_bus.tell publish(event: 42.0)
+
+      expect_message(42.0)
+      expect_no_message(timeout: 0.1)
+    end
+  end
+
+  context "when subscribed a subclass of an event" do
+    before do
+      event_bus.tell subscribe(event: Float, subscriber: test_actor)
+    end
+
+    it "does not receive an event" do
+      event_bus.tell publish(event: 42)
+
+      expect_no_message(timeout: 0.1)
+    end
+  end
+
+  context "when two different subscribers subscribed to the same event" do
+    let(:subscriber1) { system.actor_of(ActorWithInspector.props(inspector: test_actor)) }
+    let(:subscriber2) { system.actor_of(ActorWithInspector.props(inspector: test_actor)) }
+
+    before do
+      event_bus.tell subscribe(event: Numeric, subscriber: subscriber1)
+      event_bus.tell subscribe(event: Numeric, subscriber: subscriber2)
+    end
+
+    it "each subscriber receives an event" do
+      event_bus.tell publish(event: 42)
+
+      expect_message(42)
+      expect_message(42)
+    end
+  end
+end


### PR DESCRIPTION
The EventBus class enables other actors to subscribe to specific events and receive notifications when these events are published to the event bus. Here is an example of how to use this functionality:

```ruby
  event_bus = system.actor_of(EventBus.props)
  event_bus.tell EventBus::Subscribe.new(event: Numeric, subscriber: actor_ref2)
  event_bus.tell EventBus::Subscribe.new(event: Float, subscriber: actor_ref2)
  event_bus.tell EventBus::Publish.new(event: 42.2)
```

In the above example, only +actor_ref2+ receives the +42.2+ message. However, if you publish +424+ it will be received by both actors.