### PR TITLE
Implement Event Stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,52 @@ Signal.trap("INT") {
 This signal handler ensures that all actor systems are terminated when the user presses Ctrl+C or sends an 
 interrupt signal to the application.
 
+### Event Stream 
+
+Each Actor System has its own Event Stream, it enables actors to communicate through a central
+event bus. Using Event Stream, actors can both publish and subscribe to certain messages from
+the bus.
+
+While the `EventStream` primarily is meant to cater to the internal requirements of the `Next` framework, 
+it can also be used by end users for their specific needs. The main entry point for interacting with 
+`EventStream` is through `system.event_stream` which can be accessed from inside an actor 
+using `context.system.event_stream`.
+
+EventStream provides a subscribe method to listen to specific events. The method takes two 
+parameters: the `subscriber` (which should be an actor `Reference`) and the type of event 
+to be listened.
+
+```ruby 
+system.event_stream.subscribe(subscriber, Numeric)
+```
+
+To publish an event, you use the publish method of the Event Stream:
+
+```ruby
+system.event_stream.publish(42)
+system.event_stream.publish(42.2)
+```
+
+The event are matched with subscriptions using the `#===` method. Which means that in 
+the above example, `subscriber` receives both events (`42` and `42.2`). Indeed:
+
+```ruby
+Numeric === 42 #=> true 
+Numeric === 42.2 #=> true 
+```
+
+However, if you subscribe to a `Float` instead of `Numeric`, subscriber receives only the 
+second event:
+
+```ruby 
+system.event_stream.subscribe(subscriber, Float)
+system.event_stream.publish(42)
+system.event_stream.publish(42.2)
+
+expect_message(42.2)
+expect_no_message(42)
+```
+
 ### Testing
 
 `Next` comes with RSpec support. To activate it, include `rext/testing/rspec` and use the `:actor_system` shared context.

--- a/lib/next/event_stream.rb
+++ b/lib/next/event_stream.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Next
+  # Represents an event stream that allows subscribing and publishing events.
+  #
+  # @see Next::EventBus
+  # @api private
+  class EventStream
+    attr_reader :event_bus
+
+    def initialize(event_bus:)
+      @event_bus = event_bus
+    end
+
+    # Subscribes a subscriber to an event on the event bus.
+    #
+    # @param subscriber The subscriber Reference to be subscribed.
+    # @param event The event to be subscribed to (should respond to +#===+ method).
+    def subscribe(subscriber, event)
+      raise ArgumentError, "subscriber should be type of Reference" unless subscriber.is_a?(Reference)
+
+      event_bus.tell EventBus::Subscribe.new(event:, subscriber:)
+
+      self
+    end
+
+    # Publishes an event to the event bus.
+    #
+    # @param [Object] event The event to be published.
+    # @return [EventStream] The EventStream instance.
+    def publish(event)
+      event_bus.tell EventBus::Publish.new(event:)
+
+      self
+    end
+  end
+end

--- a/lib/next/system.rb
+++ b/lib/next/system.rb
@@ -12,6 +12,8 @@ module Next
     attr_reader :user_root
     private :user_root
 
+    attr_reader :event_stream
+
     class << self
       # Gracefully terminates all known actor systems
       def terminate_all!
@@ -26,6 +28,7 @@ module Next
       @name = name
 
       start_actor_system
+      start_event_stream
       when_terminated.each { puts "\nActor System `#{name}` has been terminated." }
 
       freeze
@@ -81,6 +84,13 @@ module Next
       @user_root = Reference.new(USER_ROOT_PROPS, name: "user", parent: @root, system: self)
 
       root << SystemMessages::Supervise.new(user_root)
+    end
+
+    private def start_event_stream
+      event_bus = Reference.new(EventBus.props, name: "event_stream", parent: @root, system: self)
+      root << SystemMessages::Supervise.new(event_bus)
+
+      @event_stream = EventStream.new(event_bus:)
     end
   end
 end

--- a/sig/next/event_stream.rbs
+++ b/sig/next/event_stream.rbs
@@ -1,0 +1,11 @@
+module Next
+  class EventStream
+    attr_reader event_bus: Reference
+
+    def initialize: (event_bus: Reference) -> void
+
+    def publish: (untyped) -> self
+
+    def subscribe: (Reference, untyped) -> self
+  end
+end

--- a/sig/next/system.rbs
+++ b/sig/next/system.rbs
@@ -6,6 +6,7 @@ module Next
 
     def self.terminate_all!: -> void
 
+    attr_reader event_stream: EventStream
     attr_reader name: String
     attr_reader root: Reference
     attr_reader user_root: Reference
@@ -25,6 +26,7 @@ module Next
     private
 
     def start_actor_system: -> void
+    def start_event_stream: -> void
     def start_root: -> void
     def start_user_root: -> void
   end

--- a/spec/next/system_spec.rb
+++ b/spec/next/system_spec.rb
@@ -40,7 +40,31 @@ RSpec.describe Next::System, :actor_system do
 
       system.actor_of(EchoActor.props, "echo2").tell "sent after termination"
 
-      expect_no_message
+      expect_no_message(timeout: 0.1)
+    end
+  end
+
+  describe "event_stream" do
+    let(:event_stream) { system.event_stream }
+
+    it "subscribes to events" do
+      event_stream.subscribe(test_actor, Numeric)
+
+      event_stream.publish(42)
+      expect_message(42)
+
+      event_stream.publish(42.2)
+      expect_message(42.2)
+    end
+
+    context "when subscriber is not a reference" do
+      let(:invalid_subscriber) { double }
+
+      it "raises an ArgumentError" do
+        expect {
+          event_stream.subscribe(invalid_subscriber, 42)
+        }.to raise_error ArgumentError, "subscriber should be type of Reference"
+      end
     end
   end
 end


### PR DESCRIPTION
Each Actor System has its own Event Stream, it enables actors to communicate through a central event bus. Using Event Stream, actors can both publish and subscribe to certain messages from the bus.

While the `EventStream` primarily is meant to cater to the internal requirements of the `Next` framework, it can also be used by end users for their specific needs. The main entry point for interacting with `EventStream` is through `system.event_stream` which can be accessed from inside an actor using `context.system.event_stream`.

EventStream provides a subscribe method to listen to specific events. The method takes two parameters: the `subscriber` (which should be an actor `Reference`) and the type of event to be listened.

```ruby
system.event_stream.subscribe(subscriber, Numeric)
```

To publish an event, you use the publish method of the Event Stream:

```ruby
system.event_stream.publish(42)
system.event_stream.publish(42.2)
```

The event are matched with subscriptions using the `#===` method. Which means that in the above example, `subscriber` receives both events (`42` and `42.2`). Indeed:

```ruby
Numeric === 42 #=> true
Numeric === 42.2 #=> true
```

However, if you subscribe to a `Float` instead of `Numeric`, subscriber receives only the second event:

```ruby
system.event_stream.subscribe(subscriber, Float)
system.event_stream.publish(42)
system.event_stream.publish(42.2)

expect_message(42.2)
expect_no_message(42)
```