### PR TITLE
Implement asynchronous logging

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     next (0.1.0)
       concurrent-ruby
+      dry-configurable
       fear
       zeitwerk
 
@@ -30,6 +31,12 @@ GEM
     csv (3.3.0)
     diff-lcs (1.5.1)
     drb (2.2.1)
+    dry-configurable (0.16.1)
+      dry-core (~> 0.6)
+      zeitwerk (~> 2.6)
+    dry-core (0.9.1)
+      concurrent-ruby (~> 1.0)
+      zeitwerk (~> 2.6)
     fear (3.0.0)
       zeitwerk
     fear-rspec (0.3.0)

--- a/README.md
+++ b/README.md
@@ -245,6 +245,55 @@ Signal.trap("INT") {
 This signal handler ensures that all actor systems are terminated when the user presses Ctrl+C or sends an 
 interrupt signal to the application.
 
+### Logging
+
+In the Next framework, you can perform logging from within your actors by including `Next::Logging` 
+module and using the log method.
+
+```ruby 
+class MyActor < Next::Actor
+  include Next::Logging
+
+  def receive(message)
+    log.info("#{message} received")
+  end
+end
+```
+
+There are multiple log levels available for usage:
+
+* log.info("message") - for informational messages
+* log.debug("message") - for debug-level messages
+* log.warn("message") - for warnings
+* log.error("message") - for error messages
+
+Optionally, the name of the program can be passed:
+
+```ruby 
+log.info("message", "my actor")
+```
+
+The logging in the Next framework is asynchronous implying the following:
+* **Performant**: the logging doesn't block IO operations and therefore doesn't 
+  halt the execution of your actors.
+* **Temporal mismatch**: The timestamp of logs may not always correspond to the time 
+  the logs were generated due to the asynchronous nature.
+* **Potential for lost data**: In case of actor system termination, there might be unwritten 
+  logs in memory which could get lost.
+
+
+To configure a logger (by default `$stdout` is used) you can pass an option configuration 
+block to the `Next.system` method:
+
+```ruby 
+system = Next.system('my_system') do |config|
+  config.logger = Logger.new('/path/to/your/logfile.log')
+end
+```
+
+Under the hood, `Next` uses `Next::System#event_stream` to collect logs. See the following section 
+to learn more about Event Stream.
+  
 ### Event Stream 
 
 Each Actor System has its own Event Stream, it enables actors to communicate through a central

--- a/Steepfile
+++ b/Steepfile
@@ -11,6 +11,7 @@ target :lib do
   library "delegate"              # Standard libraries
   library "securerandom"          # Standard libraries
   library "timeout"
+  library "logger"
 
   ignore "lib/next/testing/rspec.rb"
   ignore "lib/next/testing/expectations.rb"

--- a/examples/99-bottles.rb
+++ b/examples/99-bottles.rb
@@ -64,7 +64,9 @@ class Conductor < Next::Actor
   end
 end
 
-system = Next.system("99-bottles")
+system = Next.system("99-bottles") do |config|
+  config.logger = Logger.new($stdout)
+end
 
 singer = system.actor_of(Singer.props, "singer")
 conductor = system.actor_of(Conductor.props(singer:), "conductor")

--- a/lib/next.rb
+++ b/lib/next.rb
@@ -17,7 +17,7 @@ module Next
       Concurrent.global_io_executor
     end
 
-    def system(name) = System.new(name)
+    def system(name, &configuration) = System.new(name, &configuration)
   end
 end
 

--- a/lib/next/context.rb
+++ b/lib/next/context.rb
@@ -132,6 +132,16 @@ module Next
       end
     end
 
+    # Main asynchronous logging interface
+    #
+    # @example
+    #   log.info("message", "progname")
+    #   log.info("message")
+    #
+    def log
+      system.log
+    end
+
     # Unregister child
     private def add_child(child)
       @children[child.name] = child

--- a/lib/next/event_bus.rb
+++ b/lib/next/event_bus.rb
@@ -13,6 +13,8 @@ module Next
   # In the above example, only +actor_ref2+ receives the +42.2+ message. However, if you publish +424+
   # it will be received by both actors.
   #
+  # TODO: unsubscribe terminated actors
+  #
   # @api private
   class EventBus < Actor
     attr_reader :subscriptions

--- a/lib/next/logger.rb
+++ b/lib/next/logger.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Next
+  # Log listener subscribes to +Next::Logger::LogEvent+ events and
+  # reports them to provided logger.
+  #
+  # @api private
+  class Logger < Actor
+    def self.props(logger:) = Props.new(self, logger:)
+
+    attr_reader :logger
+
+    def initialize(logger:)
+      @logger = logger
+    end
+
+    def receive(event)
+      case event
+      in Logger::LogEvent(message:, progname:, level:)
+        logger.add(level, message, progname)
+      end
+    end
+  end
+end

--- a/lib/next/logger/debug.rb
+++ b/lib/next/logger/debug.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Next
+  class Logger < Actor
+    class Debug < LogEvent
+      def initialize(message:, progname: nil)
+        super(message:, progname:, level: ::Logger::DEBUG)
+      end
+    end
+  end
+end

--- a/lib/next/logger/error.rb
+++ b/lib/next/logger/error.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Next
+  class Logger < Actor
+    class Error < LogEvent
+      def initialize(message:, progname: nil)
+        super(message:, progname:, level: ::Logger::ERROR)
+      end
+    end
+  end
+end

--- a/lib/next/logger/fatal.rb
+++ b/lib/next/logger/fatal.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Next
+  class Logger < Actor
+    class Fatal < LogEvent
+      def initialize(message:, progname: nil)
+        super(message:, progname:, level: ::Logger::FATAL)
+      end
+    end
+  end
+end

--- a/lib/next/logger/info.rb
+++ b/lib/next/logger/info.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Next
+  class Logger < Actor
+    class Info < LogEvent
+      def initialize(message:, progname: nil)
+        super(message:, progname:, level: ::Logger::INFO)
+      end
+    end
+  end
+end

--- a/lib/next/logger/log_event.rb
+++ b/lib/next/logger/log_event.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Next
+  class Logger < Actor
+    # @abstract
+    # @api private
+    LogEvent = Data.define(:progname, :message, :level)
+  end
+end

--- a/lib/next/logger/unknown.rb
+++ b/lib/next/logger/unknown.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Next
+  class Logger < Actor
+    class Unknown < LogEvent
+      def initialize(message:, progname: nil)
+        super(message:, progname:, level: ::Logger::UNKNOWN)
+      end
+    end
+  end
+end

--- a/lib/next/logger/warn.rb
+++ b/lib/next/logger/warn.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Next
+  class Logger < Actor
+    class Warn < LogEvent
+      def initialize(message:, progname: nil)
+        super(message:, progname:, level: ::Logger::WARN)
+      end
+    end
+  end
+end

--- a/lib/next/logging.rb
+++ b/lib/next/logging.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Next
+  # This is the main logging interface available for user actors.
+  #
+  # Usage:
+  #   class MyActor < Next::Actor
+  #     include Next::Logging
+  #
+  #     def receive(message)
+  #       log.info("#{message} received")
+  #     end
+  #   end
+  #
+  # There are all common methods available for your disposal:
+  #
+  #   log.info("message")
+  #   log.debug("message")
+  #   log.warn("message")
+  #   log.error("message")
+  #   log.fatal("message")
+  #
+  # optionally, you can pass the name of the program:
+  #
+  #   log.info("message", "my actor")
+  #
+  # Keep in mind that logging is asynchronous and the message timestamp may not necessarily
+  # match the time when the logger is called.
+  #
+  module Logging
+    # @type module: Actor.class
+
+    def log
+      context.log
+    end
+  end
+end

--- a/lib/next/logging/log.rb
+++ b/lib/next/logging/log.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Next
+  module Logging
+    # Provides interface for asynchronous logging
+    # @see System#log
+    class Log
+      attr_reader :event_stream
+      private :event_stream
+
+      def initialize(system)
+        @event_stream = system.event_stream
+      end
+
+      def info(message, progname = nil)
+        publish(Logger::Info.new(message:, progname:))
+      end
+
+      def debug(message, progname = nil)
+        publish(Logger::Debug.new(message:, progname:))
+      end
+
+      def warn(message, progname = nil)
+        publish(Logger::Warn.new(message:, progname:))
+      end
+
+      def error(message, progname = nil)
+        publish(Logger::Error.new(message:, progname:))
+      end
+
+      def fatal(message, progname = nil)
+        publish(Logger::Fatal.new(message:, progname:))
+      end
+
+      private def publish(...)
+        event_stream.publish(...)
+
+        self
+      end
+    end
+  end
+end

--- a/lib/next/serialized_execution_delegator.rb
+++ b/lib/next/serialized_execution_delegator.rb
@@ -26,10 +26,10 @@ module Next
       self
     end
 
-    def post(*, &task)
+    def post(envelope, &task)
       Kernel.raise ArgumentError.new("no block given") unless task
       return false unless running?
-      @serializer.post(@executor, *, &task)
+      @serializer.post(@executor, envelope, &task)
     end
   end
 end

--- a/lib/next/user_root.rb
+++ b/lib/next/user_root.rb
@@ -3,7 +3,12 @@
 module Next
   # Root is the parent of all the actors defined by a user.
   class UserRoot < Actor
+    # include Logging
     CreateActor = Data.define(:props, :name, :promise)
+
+    # def initialize
+    #   log.info("Actor System `%s` started.", context.system.name)
+    # end
 
     def receive(message)
       case message

--- a/next.gemspec
+++ b/next.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "dry-configurable"
   spec.add_dependency "zeitwerk"
   spec.add_dependency "fear"
   spec.add_dependency "concurrent-ruby"

--- a/sig/gems/dry/configurable.rbs
+++ b/sig/gems/dry/configurable.rbs
@@ -1,0 +1,14 @@
+module Dry
+  module Configurable
+    def configure: { () [self: _Settings] -> void } -> self
+
+    interface _Settings
+      def setting: (
+          Symbol name,
+          ?reader: bool,
+          ?default: untyped,
+          ?constructor: ^(untyped) -> untyped
+        ) ?{ () [self: _Settings] -> void } -> void
+    end
+  end
+end

--- a/sig/gems/fear/promise.rbs
+++ b/sig/gems/fear/promise.rbs
@@ -1,5 +1,7 @@
 module Fear
   class Promise[T]
     def to_future: -> Future[T]
+    def success!: (T) -> self
+    def failure!: (StandardError) -> self
   end
 end

--- a/sig/next.rbs
+++ b/sig/next.rbs
@@ -5,5 +5,5 @@ module Next
 
   def self?.props: [T < Actor] (untyped, **untyped) -> Props[T]
   def self?.default_executor: -> Concurrent::AbstractExecutorService
-  def self?.system: (String) -> System
+  def self?.system: (String) { () [self: Dry::Configurable::_Settings] -> void }-> System
 end

--- a/sig/next/context.rbs
+++ b/sig/next/context.rbs
@@ -22,6 +22,8 @@ module Next
 
     def become: (Symbol) -> void
 
+    def log: -> Logging::Log
+
     def sender: -> Reference
 
     private

--- a/sig/next/logger.rbs
+++ b/sig/next/logger.rbs
@@ -1,0 +1,11 @@
+module Next
+  class Logger < Actor
+    def self.props: [T < Logger ](logger: T) -> Props[Logger]
+
+    attr_reader logger: ::Logger
+
+    def initialize: (logger: ::Logger) -> void
+
+    def receive: (LogEvent) -> void
+  end
+end

--- a/sig/next/logger/debug.rbs
+++ b/sig/next/logger/debug.rbs
@@ -1,0 +1,8 @@
+module Next
+  class Logger < Actor
+    class Debug < LogEvent
+      def self.new: (message: untyped, ?progname: String?) -> instance
+      def initialize: (message: untyped, ?progname: String?) -> void
+    end
+  end
+end

--- a/sig/next/logger/error.rbs
+++ b/sig/next/logger/error.rbs
@@ -1,0 +1,8 @@
+module Next
+  class Logger < Actor
+    class Error < LogEvent
+      def self.new: (message: untyped, ?progname: String?) -> instance
+      def initialize: (message: untyped, ?progname: String?) -> void
+    end
+  end
+end

--- a/sig/next/logger/fatal.rbs
+++ b/sig/next/logger/fatal.rbs
@@ -1,0 +1,8 @@
+module Next
+  class Logger < Actor
+    class Fatal < LogEvent
+      def self.new: (message: untyped, ?progname: String?) -> instance
+      def initialize: (message: untyped, ?progname: String?) -> void
+    end
+  end
+end

--- a/sig/next/logger/info.rbs
+++ b/sig/next/logger/info.rbs
@@ -1,0 +1,8 @@
+module Next
+  class Logger < Actor
+    class Info < LogEvent
+      def self.new: (message: untyped, ?progname: String?) -> instance
+      def initialize: (message: untyped, ?progname: String?) -> void
+    end
+  end
+end

--- a/sig/next/logger/log_event.rbs
+++ b/sig/next/logger/log_event.rbs
@@ -1,0 +1,11 @@
+module Next
+  class Logger < Actor
+    class LogEvent < Data
+      attr_reader progname: String?
+      attr_reader message: untyped
+      attr_reader level: Numeric
+
+      def initialize: (?progname: String?, message: untyped, level: Numeric) -> void
+    end
+  end
+end

--- a/sig/next/logger/unknown.rbs
+++ b/sig/next/logger/unknown.rbs
@@ -1,0 +1,8 @@
+module Next
+  class Logger < Actor
+    class Unknown < LogEvent
+      def self.new: (message: untyped, ?progname: String?) -> instance
+      def initialize: (message: untyped, ?progname: String?) -> void
+    end
+  end
+end

--- a/sig/next/logger/warn.rbs
+++ b/sig/next/logger/warn.rbs
@@ -1,0 +1,8 @@
+module Next
+  class Logger < Actor
+    class Warn < LogEvent
+      def self.new: (message: untyped, ?progname: String?) -> instance
+      def initialize: (message: untyped, ?progname: String?) -> void
+    end
+  end
+end

--- a/sig/next/logging.rbs
+++ b/sig/next/logging.rbs
@@ -1,0 +1,5 @@
+module Next
+  module Logging
+    def log: -> Log
+  end
+end

--- a/sig/next/logging/log.rbs
+++ b/sig/next/logging/log.rbs
@@ -1,0 +1,26 @@
+module Next
+  module Logging
+    # This is the main interface for logging. It performs asynchronous logging
+    # using a Event Stream.
+    #
+    class Log
+      attr_reader event_stream: EventStream
+
+      def initialize: (System) -> void
+
+      def info: (untyped, ?String?) -> void
+
+      def debug: (untyped, ?String?) -> void
+
+      def warn: (untyped, ?String?) -> void
+
+      def error: (untyped, ?String?) -> void
+
+      def fatal: (untyped, ?String?) -> void
+
+      private
+
+      def publish: (Logger::LogEvent) -> self
+    end
+  end
+end

--- a/sig/next/system.rbs
+++ b/sig/next/system.rbs
@@ -1,5 +1,12 @@
 module Next
   class System
+    interface _Config
+      def logger: -> Logger
+    end
+
+    include Dry::Configurable
+    extend Dry::Configurable::_Settings
+
     TERMINATION_AWAIT_TIMEOUT: Numeric
     ROOT_PROPS: Props[Root]
     USER_ROOT_PROPS: Props[UserRoot]
@@ -7,15 +14,21 @@ module Next
     def self.terminate_all!: -> void
 
     attr_reader event_stream: EventStream
+    attr_reader log: Logging::Log
     attr_reader name: String
     attr_reader root: Reference
     attr_reader user_root: Reference
 
-    def initialize: (String) -> void
+    def initialize: (String) { () [self: Dry::Configurable::_Settings] -> void } -> void
+
+    def config: -> _Config
+
+    def __log__: -> Logging::Log
 
     def actor_of: [T < Actor] (Props[T], ?String) -> Reference
 
     def await_termination: -> Fear::Try[Terminated]
+
 
     def terminate: -> Fear::Future[Terminated]
 
@@ -25,6 +38,7 @@ module Next
 
     private
 
+    def initialize_logging: -> void
     def start_actor_system: -> void
     def start_event_stream: -> void
     def start_root: -> void

--- a/sig/next/user_root.rbs
+++ b/sig/next/user_root.rbs
@@ -1,5 +1,7 @@
 module Next
   class UserRoot < Actor
+    include Logging
+
     class CreateActor < Data
       attr_reader props: Props[Actor]
       attr_reader name: String
@@ -7,5 +9,11 @@ module Next
 
       def self.new: [T < Actor] (props: Props[T], name: String, promise: Fear::Promise[Reference]) -> instance
     end
+
+    def initialize: -> void
+
+    private
+
+    def create_actor: (props: Props[untyped], name: String, promise: Fear::Promise[Reference]) -> void
   end
 end

--- a/spec/next/logger_spec.rb
+++ b/spec/next/logger_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe Next::Logger, :actor_system do
+  let(:logger_ref) { system.actor_of(props) }
+  let(:props) { Next.props(described_class, logger:) }
+  let(:logger) { instance_double(Logger) }
+
+  shared_examples Next::Logger do |log_event|
+    context "when an event with `#{log_event.level}` severity received" do
+      after do
+        logger_ref.tell Next::PoisonPill
+        Fear::Await.result(logger_ref.termination_future, 3)
+      end
+
+      it "calls Logger#add with the giver serverity" do
+        expect(logger).to receive(:add).with(log_event.level, log_event.message, log_event.progname)
+
+        logger_ref.tell log_event
+      end
+    end
+  end
+
+  include_examples Next::Logger, Next::Logger::Info.new(message: "Hi!", progname: "Next::Actor")
+  include_examples Next::Logger, Next::Logger::Debug.new(message: "Hi!", progname: "Next::Actor")
+  include_examples Next::Logger, Next::Logger::Warn.new(message: [], progname: "Next::Actor")
+  include_examples Next::Logger, Next::Logger::Error.new(message: StandardError.new, progname: "Next::Actor")
+  include_examples Next::Logger, Next::Logger::Fatal.new(message: "Hi!", progname: "Next::Actor")
+  include_examples Next::Logger, Next::Logger::Unknown.new(message: "Hi!", progname: "Next::Actor")
+end


### PR DESCRIPTION
In the Next framework, you can perform logging from within your actors by including `Next::Logging` module and using the log method.

```ruby
class MyActor < Next::Actor
  include Next::Logging

  def receive(message)
    log.info("#{message} received")
  end
end
```

There are multiple log levels available for usage:

* log.info("message") - for informational messages
* log.debug("message") - for debug-level messages
* log.warn("message") - for warnings
* log.error("message") - for error messages

Optionally, the name of the program can be passed:

```ruby
log.info("message", "my actor")
```

The logging in the Next framework is asynchronous implying the following:
* **Performant**: the logging doesn't block IO operations and therefore doesn't halt the execution of your actors.
* **Temporal mismatch**: The timestamp of logs may not always correspond to the time the logs were generated due to the asynchronous nature.
* **Potential for lost data**: In case of actor system termination, there might be unwritten logs in memory which could get lost.

To configure a logger (by default `$stdout` is used) you can pass an option configuration block to the `Next.system` method:

```ruby
system = Next.system('my_system') do |config|
  config.logger = Logger.new('/path/to/your/logfile.log')
end
```

Under the hood, `Next` uses `Next::System#event_stream` to collect logs. See the following section to learn more about Event Stream.